### PR TITLE
support access over proxy.

### DIFF
--- a/lib/gdata/http/default_service.rb
+++ b/lib/gdata/http/default_service.rb
@@ -29,7 +29,8 @@ module GData
       # GData::HTTP::Response object.
       def make_request(request)
         url = URI.parse(request.url)
-        http = Net::HTTP.new(url.host, url.port)
+        proxy = URI::parse((url.scheme == 'https' ? ENV['https_proxy'] : ENV['http_proxy']) || '')
+        http = Net::HTTP.new(url.host, url.port, proxy.host, proxy.port)
         http.use_ssl = (url.scheme == 'https')
         http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         


### PR DESCRIPTION
Support access over proxy in GData::HTTP::DefaultService#make_request, using environment variable 'http_proxy' or 'https_proxy'.
