### PR TITLE
send request with SSL

### DIFF
--- a/lib/gdata/client/base.rb
+++ b/lib/gdata/client/base.rb
@@ -72,7 +72,7 @@ module GData
       def make_request(method, url, body = '')
         headers = self.prepare_headers
         request = GData::HTTP::Request.new(url, :headers => headers, 
-          :method => method, :body => body)
+          :method => method, :body => body, :secure => true )
         
         if @auth_handler and @auth_handler.respond_to?(:sign_request!)
           @auth_handler.sign_request!(request)


### PR DESCRIPTION
when i started using the gem i got the follow exception

GData::Client::AuthorizationError: request error 403: <errors xmlns='http://schemas.google.com/g/2005'><error><domain>GData</domain><code>ServiceForbiddenException</code><internalReason>403.4 SSL required</internalReason></error></errors>

requests to google should be secure, so here is a proposed tiny change to make it work
